### PR TITLE
PA251 Account creation for admins

### DIFF
--- a/api/controllers/user_view.py
+++ b/api/controllers/user_view.py
@@ -20,10 +20,24 @@ class UserViewSet(viewsets.ViewSet):
     # Authorization: Bearer <accessToken>
     # to call GET /api/user
     def get_permissions(self):
-        if self.action == "list" or "delete":
+        if self.action in ["list", "delete", "create"]:
             return [IsAuthenticated()]
 
         return [AllowAny()]
+
+    def create(self, request):
+        """
+        Create a new user. Authorised only for admins.
+        POST /api/user
+        """
+        if request.user.role != ROLE.ADMIN.value:
+            return Response({'error': 'Permission denied. Admin role required.'}, status=status.HTTP_403_FORBIDDEN)
+
+        serializer = UserModelSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def list(self, request):
         """

--- a/authentication/authentication_view.py
+++ b/authentication/authentication_view.py
@@ -7,6 +7,7 @@ from rest_framework_simplejwt.exceptions import TokenError
 from api.serializers import UserModelSerializer
 from base import Constants
 from base import utils
+from base.enums import ROLE
 from base.models import *
 
 class AuthenticationViewSet(viewsets.ViewSet):
@@ -30,6 +31,7 @@ class AuthenticationViewSet(viewsets.ViewSet):
             "role": string (correspond to the "role" enum)
         }
         """
+        request.data["role"] = ROLE.CUSTOMER
         serializer = UserModelSerializer(data=request.data)
         if serializer.is_valid():
             user = serializer.save()

--- a/base/enums/role.py
+++ b/base/enums/role.py
@@ -6,4 +6,5 @@ class ROLE(Enum):
     """
     CUSTOMER = "customer"
     SELLER = "seller"
+    MANAGER = "manager"
     ADMIN = "admin"

--- a/base/utils.py
+++ b/base/utils.py
@@ -15,5 +15,5 @@ def verify_hashed_refresh(user, raw_refresh_token):
     return check_password(raw_refresh_token, user.refreshToken)
 
 def clear_hashed_refresh(user):
-    user.refreshToken = ""
+    user.refreshToken = None
     user.save(update_fields=[Constants.REFRESH_TOKEN])


### PR DESCRIPTION
### Summary

- Created new `create()` method on the `user_view`, to allow admin users to create a new user model, without using signup endpoint
- Added manager role to role enum
- Enforced customer role for signup endpoint
- Updated utils.py to set a user's refreshToken to null instead of an empty string. I was having issues with the fact that refreshToken has a unique constraint, but multiple users could have their refreshToken set as "" (I wasn't able to logout of an account because another user already had an empty refreshToken). Setting it to [null] fixes this issue. Let me know if there's any problems with this approach.

Corresponding frontend PR: https://github.com/Capstone-56/ecommerce-frontend/pull/89